### PR TITLE
ci: runs activitypub-testing-fep-521a in addition to core tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,33 @@ runs `server.ts`, then run `activitypub-testing test actor` against the running 
 
 #### main
 
-main workflow. runs on every push.
+main workflow. runs tests on every push.
 
 ##### jobs
 
 ###### test
 
 test the activitypub-testing-fedify package using `npm test`.
+
+#### activitypub-testing
+
+on ever push, run `activitypub-testing test actor $server/users/me` against the server.
+
+##### jobs
+
+###### tap-summary
+
+reports on the test results.
+
+This is a WIP job
+* [x] prototype with fake TAP in [tap/01-common.tap](./tap/01-common.tap)
+* [ ] activitypub-testing should output TAP or JUnit
+* [ ] prototype script that converts existing activitypub-testing JSON output to TAP
+* [ ] replace 01-common.tap with TAP output from activitypub-testing in this tap-summary job
+
+###### test-actor
+
+runs `activitypub-testing test actor` against the server using `bin/activitypub-testing`
 
 ### run locally with nektos/act
 

--- a/bin/activitypub-testing
+++ b/bin/activitypub-testing
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck disable=SC3041
+set -eE; # start exit on error
+
 help() {
   echo "boots the server, then runs activitypub-testing against it"
 }
@@ -8,9 +11,13 @@ err() {
   >&2 echo "$@"
 }
 
+fetchActivityPubObject() {
+  curl -H 'Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"' "$1"
+}
+
 main() {
   err; err running server
-  npx tsx server.ts &
+  >&2 npx tsx server.ts &
   serverUrl=http://localhost:8000
 
   err; err waiting for server to be available at $serverUrl
@@ -21,13 +28,19 @@ main() {
   err; err server is available at $serverUrl
 
   me="$serverUrl/users/me"
-  err; err fetching "$me"
-  curl -v "$me" -H "Accept: application/json"
 
   err; err running \`activitypub-testing test actor "$me"\`
   npx activitypub-testing test actor "$me"
   err finished running \`activitypub-testing test actor "$me"\`
 
+  err; err fetching actor
+  actorJson="$(fetchActivityPubObject "$me")"
+
+  err; err running custom test /fep/521a/actor-objects-must-express-signing-key-as-assertionMethod-multikey.js
+  npx activitypub-testing run test \
+    --url=https://codeberg.org/socialweb.coop/activitypub-testing-fep-521a/raw/branch/main/fep/521a/actor-objects-must-express-signing-key-as-assertionMethod-multikey.js \
+    --input.actor="$actorJson"
+  err; err finished running custom test /fep/521a/actor-objects-must-express-signing-key-as-assertionMethod-multikey.js
 }
 
 cleanup() {

--- a/bin/assertion-ndjson-to-tap.js
+++ b/bin/assertion-ndjson-to-tap.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import { createReadStream, existsSync } from "fs"
+import readNDJSONStream from 'ndjson-readablestream';
+import { ReadableStream } from "stream/web";
+
+/**
+ * @param {object} options
+ */
+async function main(options = {}) {
+  console.log('hi', process.stdin.isTTY, process.argv)
+  const assertionsFilePath = process.argv[2]
+  if (!existsSync(assertionsFilePath)) {
+    throw new Error(`file does not exist`, {
+      cause: assertionsFilePath
+    })
+  }
+
+  for await (const assertion of readNDJSONStream(ReadableStream.from(createReadStream(assertionsFilePath)))) {
+    console.log('assertion', assertion)
+  }
+}
+
+await main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@hono/node-server": "^1.11.4",
         "@logtape/logtape": "^0.4.0",
         "hono": "^4.4.7",
+        "ndjson-readablestream": "^1.2.0",
         "tsx": "^4.15.6",
         "x-forwarded-fetch": "^0.2.0"
       },
@@ -7001,6 +7002,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/ndjson-readablestream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ndjson-readablestream/-/ndjson-readablestream-1.2.0.tgz",
+      "integrity": "sha512-QbWX2IIfKMVL+ZFHm9vFEzPh1NzZfzJql59T+9XoXzUp8n0wu2t9qgDV9nT0A77YYa6KbAjsHNWzJfpZTfp4xQ=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.10.1",
-        "activitypub-testing": "^0.14.0",
+        "activitypub-testing": "^0.15.0",
         "tap": "^19.2.5",
         "tap-junit": "^5.0.3",
         "typescript": "^5.5.2"
@@ -2803,9 +2803,9 @@
       }
     },
     "node_modules/activitypub-testing": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/activitypub-testing/-/activitypub-testing-0.14.0.tgz",
-      "integrity": "sha512-gqgKl4dKW0WTDzYVoYBC97YyfJ1ASVbzghz3If3iAh41fbEyl50b8bs+jYxEMmxKBpI32MViKtshEKa4SXohNg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/activitypub-testing/-/activitypub-testing-0.15.0.tgz",
+      "integrity": "sha512-/fY/x9zkBnkoIwGwYNkQe+ZhSnoMOj500p4Tzdm4fUyMd+fjB1Jj3eLcQ1o4cKHJENpGC30xqy2Q9S9A1I8PxQ==",
       "dev": true,
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.1",
-    "activitypub-testing": "^0.14.0",
+    "activitypub-testing": "^0.15.0",
     "tap": "^19.2.5",
     "tap-junit": "^5.0.3",
     "typescript": "^5.5.2"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@hono/node-server": "^1.11.4",
     "@logtape/logtape": "^0.4.0",
     "hono": "^4.4.7",
+    "ndjson-readablestream": "^1.2.0",
     "tsx": "^4.15.6",
     "x-forwarded-fetch": "^0.2.0"
   }


### PR DESCRIPTION
Motivation:
* proof of concept to ensure that the new `activitypub-testing run test --url=<url>` from @0.15.0 can run a test at URL in https://codeberg.org/socialweb.coop/activitypub-testing-fep-521a/ so others can copypasta the configuration to do something similar in their repos, i.e. use activitypub-testing in their CI jobs for continuous conformance testing